### PR TITLE
Updated color for Preformatted code background

### DIFF
--- a/sample/Dracula
+++ b/sample/Dracula
@@ -40,7 +40,7 @@ muted-foreground: rgba(255,255,255,0.5)
 notification-background: #bd93f9
 notification-border: #bd93f9
 page-background: #282a36
-pre-background: <<colour page-background>>
+pre-background: #343746
 pre-border: <<colour page-background>>
 primary: #8be9fd
 sidebar-button-foreground: <<colour foreground>>


### PR DESCRIPTION
Adding background color of preformatted code.

<img width="967" alt="Screen Shot 2023-01-15 at 10 27 18 PM" src="https://user-images.githubusercontent.com/79547/212605439-93a3aa07-7dd5-41cf-841d-0de56bd701b0.png">
<img width="971" alt="Screen Shot 2023-01-15 at 10 26 36 PM" src="https://user-images.githubusercontent.com/79547/212605449-21d4d9e9-e48b-4161-91b0-7b3b57f582df.png">
